### PR TITLE
ProfileRules not imported for non-Brazil countries

### DIFF
--- a/react/ProfileRules.js
+++ b/react/ProfileRules.js
@@ -19,7 +19,7 @@ class ProfileRules extends Component {
     const { shouldUseIOFetching, fetch, country } = this.props
 
     const rulePromise = shouldUseIOFetching
-      ? import(`@vtex/profile-form/lib/rules/${country}`)
+      ? import(`./rules/${country}`)
       : fetch(country)
     return this.fetchRules(rulePromise)
   }

--- a/react/ProfileRules.js
+++ b/react/ProfileRules.js
@@ -19,7 +19,7 @@ class ProfileRules extends Component {
     const { shouldUseIOFetching, fetch, country } = this.props
 
     const rulePromise = shouldUseIOFetching
-      ? import(`./rules/${country}`)
+      ? import(`@vtex/profile-form/lib/rules/${country}`)
       : fetch(country)
     return this.fetchRules(rulePromise)
   }
@@ -49,7 +49,7 @@ class ProfileRules extends Component {
 
   parseError(e) {
     const regex = new RegExp(
-      /Cannot find module '\.\.\/(rules\/)?([A-z-]{1,7})'/,
+      /Cannot find module '\.\/([A-z-]{1,7})'\./,
     )
     const result = regex.exec(e.message)
     if (!result) return false


### PR DESCRIPTION
#### What is the purpose of this pull request?
When country is outside of Brazil (USA), 
`import(`@vtex/profile-form/lib/rules/${country}`)` will reject promise with following exception. 
`Cannot find module './USA'.`

The regex match to check whether the error message is about a missing country rules file is wrong. 

#### What problem is this solving?
Regex-earlier : `\.\.\/(rules\/)?([A-z-]{1,7})'/`
Error message : `Cannot find module './USA'.`
Proposed Regex : `\.\/([A-z-]{1,7})'\./`

Regex-earlier is not parsing exception correctly. 

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.