### PR TITLE
Fix empty birth date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Birth Date failing to be empty.
+
 ## [2.6.0] - 2019-05-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.6.2] - 2019-05-24
+
 ### Fixed
 
 - Birth Date failing to be empty.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "profile-form",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "title": "VTEX Profile-form",
   "description": "React component for managing user profiles",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/profile-form",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "React component for managing user profiles",
   "main": "lib/index.js",
   "files": [

--- a/react/ProfileRules.js
+++ b/react/ProfileRules.js
@@ -61,7 +61,7 @@ class ProfileRules extends Component {
     const regex = new RegExp(
       process.env.NODE_ENV === 'test'
         ? /Cannot find module '\.\.\/(rules\/)?([A-z-]{1,7})'/
-        : /Cannot find module '\.\/([A-z-]{1,7})'/
+        : /Cannot find module '\.\/([A-z-]{1,7})'/,
     )
     const result = regex.exec(e.message)
     if (!result) return false
@@ -92,7 +92,7 @@ ProfileRules.propTypes = {
 export default injectIntl(ProfileRules)
 
 export function filterDateType(fields) {
-  return fields.filter((rule) => rule.type === 'date')
+  return fields.filter(rule => rule.type === 'date')
 }
 
 export function prepareDateRules(rules, intl) {
@@ -101,12 +101,23 @@ export function prepareDateRules(rules, intl) {
 }
 
 function setDateRuleValidations(rules, intl) {
-  if(rules) {
+  if (rules) {
     rules.forEach(rule => {
       rule.mask = value => msk.fit(value, '99/99/9999')
-      rule.validate = value => moment.utc(value,'L',intl.locale.toLowerCase()).isValid()
-      rule.display = value => moment.utc(value,[moment.ISO_8601, 'L'], intl.locale.toLowerCase()).format('L')
-      rule.submit = value => moment.utc(value,'L',intl.locale.toLowerCase()).format()
+      rule.validate = value =>
+        moment.utc(value, 'L', intl.locale.toLowerCase()).isValid()
+      rule.display = value =>
+        moment
+          .utc(value, [moment.ISO_8601, 'L'], intl.locale.toLowerCase())
+          .format('L')
+      rule.submit = value => {
+        if (!value) return null
+
+        const date = moment.utc(value, 'L', intl.locale.toLowerCase(), true)
+        if (!date.isValid()) return null
+
+        return date.format()
+      }
     })
   }
 }

--- a/react/__mocks__/rules.js
+++ b/react/__mocks__/rules.js
@@ -13,6 +13,12 @@ export default {
       maxLength: 30,
     },
     {
+      name: 'birthDate',
+      maxLength: 30,
+      label: 'birthDate',
+      type: 'date',
+    },
+    {
       name: 'lastName',
       maxLength: 100,
       label: 'lastName',

--- a/react/__tests__/ProfileContainer.test.js
+++ b/react/__tests__/ProfileContainer.test.js
@@ -27,7 +27,7 @@ describe('ProfileContainer', () => {
     const result = wrapper.find(ProfileField)
 
     // Assert
-    expect(result).toHaveLength(3)
+    expect(result).toHaveLength(4)
   })
 
   it('should pass down profile data to fields', () => {
@@ -90,6 +90,7 @@ describe('ProfileContainer', () => {
     // Assert
     expect(mockSubmit).toHaveBeenCalledWith({
       profile: {
+        birthDate: '23/05/92',
         firstName: 'John',
         gender: null,
         lastName: 'Appleseed',

--- a/react/__tests__/ProfileRules.test.js
+++ b/react/__tests__/ProfileRules.test.js
@@ -1,6 +1,6 @@
 import { IntlProvider } from 'react-intl'
 
-import { prepareDateRules, filterDateType} from '../ProfileRules'
+import { prepareDateRules, filterDateType } from '../ProfileRules'
 import defaultRules from '../rules/default'
 
 const intlProvider = new IntlProvider({ locale: 'pt-br' }, {})
@@ -72,6 +72,29 @@ describe('ProfileRules aux functions', () => {
 
     prepareDateRules(rules, intl)
 
-    expect(birthDate.submit('25/11/2018')).toMatch(new RegExp('2018-11-25T([0-9])([0-9]):00:00Z'))
+    expect(birthDate.submit('25/11/2018')).toMatch(
+      new RegExp('2018-11-25T([0-9])([0-9]):00:00Z'),
+    )
+  })
+
+  describe('date', () => {
+    it('empty date should be submitted as null', () => {
+      const rules = defaultRules
+      const birthDate = filterDateType(rules.personalFields)[0]
+
+      prepareDateRules(rules, intl)
+
+      expect(birthDate.submit()).toBe(null)
+    })
+
+    it('invalid date should be submitted as null', () => {
+      const rules = defaultRules
+      const birthDate = filterDateType(rules.personalFields)[0]
+
+      prepareDateRules(rules, intl)
+
+      expect(birthDate.submit('30/28/19501')).toBe(null)
+      expect(birthDate.submit('not-a-date')).toBe(null)
+    })
   })
 })

--- a/react/__tests__/validateProfile.test.js
+++ b/react/__tests__/validateProfile.test.js
@@ -19,6 +19,7 @@ describe('validateProfile', () => {
 
     // Assert
     expect(result).toEqual({
+      birthDate: { value: '23/05/92' },
       firstName: { value: 'John' },
       gender: { value: null },
       lastName: { value: 'Appleseed' },
@@ -44,6 +45,7 @@ describe('validateProfile', () => {
 
     // Assert
     expect(result).toEqual({
+      birthDate: { value: '23/05/92' },
       firstName: { value: 'John' },
       gender: { value: null },
       lastName: { value: 'Appleseed' },
@@ -57,6 +59,7 @@ describe('validateProfile', () => {
 
     // Assert
     expect(result).toEqual({
+      birthDate: '23/05/92',
       firstName: 'John',
       gender: null,
       lastName: 'Appleseed',
@@ -85,6 +88,7 @@ describe('validateProfile', () => {
 
     // Assert
     expect(result).toEqual({
+      birthDate: '23/05/92',
       firstName: 'John',
       gender: null,
       lastName: 'Appleseed',
@@ -200,5 +204,19 @@ describe('validateProfile', () => {
 
     // Assert
     expect(checkedProfile.stateRegistration.error).toBeTruthy()
+  })
+
+  it('should validate empty birth date as null', () => {
+    // Arrange
+    const profileWithNoDate = {
+      ...validatedProfile,
+      birthDate: { value: '' },
+    }
+
+    // Act
+    const validResult = removeValidation(profileWithNoDate, mockRules)
+
+    // Assert
+    expect(validResult).toMatchObject({ birthDate: null })
   })
 })

--- a/react/__tests__/validateProfile.test.js
+++ b/react/__tests__/validateProfile.test.js
@@ -206,17 +206,4 @@ describe('validateProfile', () => {
     expect(checkedProfile.stateRegistration.error).toBeTruthy()
   })
 
-  it('should validate empty birth date as null', () => {
-    // Arrange
-    const profileWithNoDate = {
-      ...validatedProfile,
-      birthDate: { value: '' },
-    }
-
-    // Act
-    const validResult = removeValidation(profileWithNoDate, mockRules)
-
-    // Assert
-    expect(validResult).toMatchObject({ birthDate: null })
-  })
 })

--- a/react/modules/removeValidation.js
+++ b/react/modules/removeValidation.js
@@ -4,14 +4,10 @@ export default function removeValidation(profile, rules) {
   return allRules.reduce((acc, field) => {
     const fieldValue = profile[field.name].value
 
-    if (field.submit && fieldValue) {
+    if (field.submit && fieldValue != null) {
       acc[field.name] = field.submit(fieldValue)
     } else {
-      if (field.type === 'date' && fieldValue === '') {
-        acc[field.name] = null
-      } else {
-        acc[field.name] = fieldValue
-      }
+      acc[field.name] = fieldValue
     }
 
     return acc

--- a/react/modules/removeValidation.js
+++ b/react/modules/removeValidation.js
@@ -2,11 +2,18 @@ export default function removeValidation(profile, rules) {
   const allRules = [...rules.personalFields, ...rules.businessFields]
 
   return allRules.reduce((acc, field) => {
-    if (field.submit && profile[field.name].value) {
-      acc[field.name] = field.submit(profile[field.name].value)
+    const fieldValue = profile[field.name].value
+
+    if (field.submit && fieldValue) {
+      acc[field.name] = field.submit(fieldValue)
     } else {
-      acc[field.name] = profile[field.name].value
+      if (field.type === 'date' && fieldValue === '') {
+        acc[field.name] = null
+      } else {
+        acc[field.name] = fieldValue
+      }
     }
+
     return acc
   }, {})
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

Our endpoint doesn't accept an empty string as a valid `Datetime` value. This PR replaces the empty string with a `null` value.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

Just try to remove an already saved birth date from your profile and `save`.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12702016/58288414-e35c9d80-7d89-11e9-9e43-8c73d932cefa.png)


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.