### PR TITLE
Fix wrong female translation in catalan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Wrong 'female' translation in catalan.
+
 ## [2.6.4] - 2019-06-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.6.5] - 2019-06-27
+
 ### Fixed
 
 - Wrong 'female' translation in catalan.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "profile-form",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "title": "VTEX Profile-form",
   "description": "React component for managing user profiles",
   "builders": {

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -49,7 +49,7 @@
   "profile-form.error.INVALID_FIELD": "No vàlid.",
   "profile-form.gender.custom": "Personalitzat",
   "profile-form.gender.male": "Home",
-  "profile-form.gender.female": "Dones",
+  "profile-form.gender.female": "Dona",
   "profile-form.gender.agender": "Envelliment",
   "profile-form.gender.androgyne": "Androgyne",
   "profile-form.gender.bigender": "Gran gènere",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/profile-form",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "description": "React component for managing user profiles",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
#### What is the purpose of this pull request?

see PR title

#### What problem is this solving?

Wrong translation for 'female' genre in catalan.

#### How should this be manually tested?

1. go to [ametllerorigen.myvtex.com](http://ametllerorigen.myvtex.com)
2. enter 'my account'
3. enter 'my profile'
4. click edit
5. female genre  is `Dona`, not `Dones`

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12702016/60274548-9e6ae000-98ce-11e9-91f4-bffc9d6cad63.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.