### PR TITLE
Fallback gender translation to value from masterdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fallback gender translation to the value returned from the `store-graphql`.
+
 ## [2.6.6] - 2019-07-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.6.7] - 2019-07-04
+
 ### Fixed
 
 - Fallback gender translation to the value returned from the `store-graphql`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "profile-form",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "title": "VTEX Profile-form",
   "description": "React component for managing user profiles",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/profile-form",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "description": "React component for managing user profiles",
   "main": "lib/index.js",
   "files": [

--- a/react/ProfileSummary.js
+++ b/react/ProfileSummary.js
@@ -25,14 +25,17 @@ class ProfileSummary extends Component {
   }
 
   translateGender(mappedData) {
+    const gender = mappedData.gender.value
     return {
       ...mappedData,
       gender: {
         ...mappedData.gender,
         value:
-          mappedData.gender.value &&
+          gender &&
           this.props.intl.formatMessage({
-            id: 'profile-form.gender.' + mappedData.gender.value,
+            id: `profile-form.gender.${gender}`,
+            // fallback to whatever came from the master data
+            defaultMessage: gender,
           }),
       },
     }
@@ -46,7 +49,11 @@ class ProfileSummary extends Component {
     )
     const businessData = this.mapFields(rules.businessFields)
 
-    return <div className="vtex-profile-form__profile-summary">{children({ personalData, businessData, isCorporate })}</div>
+    return (
+      <div className="vtex-profile-form__profile-summary">
+        {children({ personalData, businessData, isCorporate })}
+      </div>
+    )
   }
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Fallback the gender translation to the value returned by the MasterData.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

https://app.clubhouse.io/vtex-dev/story/14028/vari%C3%A1vel-sendo-exibida-de-forma-equivocada

There are cases where the MasterData's `gender` value is not a gender `id`, but the value itself:

![image](https://user-images.githubusercontent.com/12702016/60680762-07200280-9e63-11e9-8a10-b3610f7246c0.png)

#### How should this be manually tested?

1) Edit your account gender to something like `Masculino` on `recorrenciaqa`'s masterdata:
https://recorrenciaqa.vtexcrm.com.br/#RHluYW1pY0Zvcm0jRm9ybVZpZXcjZm9ybUlkPTljNjk2OWNlLWFlYTktNDc5Yi04OWVlLWVhZWUz%0aMDA5ZDViOCZyb3dJZD1DTC02YTU2M2ZlNC03MGY2LTExZTktODI4Zi0wYTUxMDhmOGI4Y2UmdXJs%0aQ2FuY2VsPSUyM1JIbHVZVzFwWTBadmNtMGpTVzVrWlhnalptOXliVWxrUFRsak5qazJPV05sTFdG%0abFlUa3RORGM1WWkwNE9XVmxMV1ZoWldVek1EQTUlMjUwYVpEVmlPQ01qSTBSNWJtRnRhV05HYjNK%0adFgwbHVaR1Y0WDB4dllXUmZVM1ZqWlhOekkwRnFZWGhTWlhGMVpYTjBSWEp5YjNJalkyOXUlMjUw%0aYWRHVnVkQSUyNTNkJTI1M2QjIyNEeW5hbWljRm9ybV9Gb3JtVmlld19BZnRlckxvYWQjQWpheFJl%0acXVlc3RFcnJvciNjb250ZW50

2) Go to your profile on this workspace: 
https://kiwi--recorrenciaqa.myvtex.com/account#/profile

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.