### PR TITLE
Fix BRA.js rules to businessPhone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- `businessPhone` to use **getPhoneFields** function, not the Phone lib that was not imported.
+- `businessPhone` to use **getPhoneFields** function, instead of the Phone lib that was not being imported.
 
 ## [2.6.7] - 2019-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `businessPhone` to use **getPhoneFields** function, not the Phone lib that was not imported.
+
 ## [2.6.7] - 2019-07-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.6.8] - 2019-07-19
+
 ### Fixed
 
 - `businessPhone` to use **getPhoneFields** function, instead of the Phone lib that was not being imported.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "profile-form",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "title": "VTEX Profile-form",
   "description": "React component for managing user profiles",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/profile-form",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "React component for managing user profiles",
   "main": "lib/index.js",
   "files": [

--- a/react/rules/BRA.js
+++ b/react/rules/BRA.js
@@ -128,10 +128,7 @@ export default {
       name: 'businessPhone',
       maxLength: 30,
       label: 'businessPhone',
-      mask: maskPhone,
-      validate: value => Phone.validate(value, '55'),
-      display: maskPhone,
-      submit: value => value.replace(/[^\d]/g, ''),
+      ...getPhoneFields(phoneCountryCode),
     },
     {
       name: 'stateRegistration',


### PR DESCRIPTION
#### What is the purpose of this pull request?

The `Phone` library was not being imported in the file anymore, since the standard usage is to use the `getPhoneFields` function.

#### What problem is this solving?

Since the library was not being used, it was not being imported. Thus, the validation for the `businessPhone` field was breaking with `Phone is undefined`.

#### How should this be manually tested?

Go to the following workspace and try to change the business phone field in the corporate documents area.

https://arthur--recorrenciaqa.myvtex.com/account#/profile

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.