### PR TITLE
Fix/birthdate accepts future date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ node_modules
 /src
 
 # misc
-/react/package.json
 .DS_Store
 .env.local
 .env.development.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.6.10] - 2019-10-01
+
 ### Changed
 
 - `birthDate` validation function for all countries to not accept future dates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `birthDate` validation function for all countries to not accept future dates.
+
 ## [2.6.9] - 2019-09-04
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "profile-form",
-  "version": "2.6.9",
+  "version": "2.6.10",
   "title": "VTEX Profile-form",
   "description": "React component for managing user profiles",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/profile-form",
-  "version": "2.6.9",
+  "version": "2.6.10",
   "description": "React component for managing user profiles",
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "addLocales": "cp -R -f messages/ lib/locales/",
     "clean": "nwb clean-module && nwb clean-demo",
     "start": "npm run symlinks && nwb serve-react-demo",
-    "symlinks": "rm -rf src && ln -sf react src && ln -sf ../package.json react/package.json",
+    "symlinks": "rm -rf src && ln -sf react src",
     "test": "jest --env=jsdom",
     "test:coverage": "jest --env=jsdom --coverage",
     "test:watch": "jest --env=jsdom --watch",

--- a/react/ProfileRules.js
+++ b/react/ProfileRules.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'react'
 import { injectIntl, intlShape } from 'react-intl'
 import PropTypes from 'prop-types'
-import moment from 'moment'
-import msk from 'msk'
+import { prepareDateRules } from './utils/dateRules'
 
 import defaultRules from './rules/default'
 
@@ -32,9 +31,9 @@ class ProfileRules extends Component {
       const ruleData = await rulePromise
       const rules = ruleData.default || ruleData
 
-      prepareDateRules(rules, intl)
+      const enhancedDateRules = prepareDateRules(rules, intl)
 
-      this.setState({ rules })
+      this.setState({ rules: enhancedDateRules })
 
       return rules
     } catch (error) {
@@ -46,9 +45,9 @@ class ProfileRules extends Component {
           )
         }
 
-        prepareDateRules(defaultRules, intl)
+        const enhancedDateRules = prepareDateRules(defaultRules, intl)
 
-        this.setState({ rules: defaultRules })
+        this.setState({ rules: enhancedDateRules })
         return defaultRules
       }
       if (process.env.NODE_ENV !== 'production') {
@@ -90,34 +89,3 @@ ProfileRules.propTypes = {
 }
 
 export default injectIntl(ProfileRules)
-
-export function filterDateType(fields) {
-  return fields.filter(rule => rule.type === 'date')
-}
-
-export function prepareDateRules(rules, intl) {
-  setDateRuleValidations(filterDateType(rules.personalFields), intl)
-  setDateRuleValidations(filterDateType(rules.businessFields), intl)
-}
-
-function setDateRuleValidations(rules, intl) {
-  if (rules) {
-    rules.forEach(rule => {
-      rule.mask = value => msk.fit(value, '99/99/9999')
-      rule.validate = value =>
-        moment.utc(value, 'L', intl.locale.toLowerCase()).isValid()
-      rule.display = value =>
-        moment
-          .utc(value, [moment.ISO_8601, 'L'], intl.locale.toLowerCase())
-          .format('L')
-      rule.submit = value => {
-        if (!value) return null
-
-        const date = moment.utc(value, 'L', intl.locale.toLowerCase(), true)
-        if (!date.isValid()) return null
-
-        return date.format()
-      }
-    })
-  }
-}

--- a/react/__tests__/ProfileRules.test.js
+++ b/react/__tests__/ProfileRules.test.js
@@ -1,6 +1,7 @@
 import { IntlProvider } from 'react-intl'
 
-import { prepareDateRules, filterDateType } from '../ProfileRules'
+import { prepareDateRules } from '../ProfileRules'
+import { filterDateType } from '../utils/dateRules'
 import defaultRules from '../rules/default'
 
 const intlProvider = new IntlProvider({ locale: 'pt-br' }, {})
@@ -22,7 +23,7 @@ describe('ProfileRules aux functions', () => {
     const birthDate = filterDateType(rules.personalFields)[0]
 
     expect(birthDate.mask).toBeUndefined()
-    expect(birthDate.validate).toBeUndefined()
+    expect(birthDate.validate).toBeDefined()
     expect(birthDate.display).toBeUndefined()
     expect(birthDate.submit).toBeUndefined()
 

--- a/react/__tests__/ProfileRules.test.js
+++ b/react/__tests__/ProfileRules.test.js
@@ -1,16 +1,22 @@
 import { IntlProvider } from 'react-intl'
 
-import { prepareDateRules } from '../ProfileRules'
-import { filterDateType } from '../utils/dateRules'
+import { prepareDateRules, filterDateType } from '../utils/dateRules'
 import defaultRules from '../rules/default'
 
 const intlProvider = new IntlProvider({ locale: 'pt-br' }, {})
 const { intl } = intlProvider.getChildContext()
 
+function getBirthDate(rules) {
+  const preparedRules = prepareDateRules(rules, intl)
+  const birthDateInitialized = preparedRules.personalFields.find(
+    rule => rule.name === 'birthDate',
+  )
+  return birthDateInitialized
+}
+
 describe('ProfileRules aux functions', () => {
   it('should filter the correct rules', () => {
     const rules = defaultRules
-
     const filteredFields = filterDateType(rules.personalFields)
 
     expect(filteredFields.length).toBe(1)
@@ -19,7 +25,6 @@ describe('ProfileRules aux functions', () => {
 
   it('should set the functions to the rules of type date', () => {
     const rules = defaultRules
-
     const birthDate = filterDateType(rules.personalFields)[0]
 
     expect(birthDate.mask).toBeUndefined()
@@ -27,53 +32,47 @@ describe('ProfileRules aux functions', () => {
     expect(birthDate.display).toBeUndefined()
     expect(birthDate.submit).toBeUndefined()
 
-    prepareDateRules(rules, intl)
+    const birthDateInitialized = getBirthDate(rules)
 
-    expect(birthDate.mask).toBeDefined()
-    expect(birthDate.validate).toBeDefined()
-    expect(birthDate.display).toBeDefined()
-    expect(birthDate.submit).toBeDefined()
+    expect(birthDateInitialized.mask).toBeDefined()
+    expect(birthDateInitialized.validate).toBeDefined()
+    expect(birthDateInitialized.display).toBeDefined()
+    expect(birthDateInitialized.submit).toBeDefined()
   })
 
   it('should mask correctly', () => {
     const rules = defaultRules
-    const birthDate = filterDateType(rules.personalFields)[0]
+    const birthDateInitialized = getBirthDate(rules)
 
-    prepareDateRules(rules, intl)
-
-    expect(birthDate.mask('100')).toBe('10/0')
-    expect(birthDate.mask('10/09')).toBe('10/09')
-    expect(birthDate.mask('10/091994')).toBe('10/09/1994')
+    expect(birthDateInitialized.mask('100')).toBe('10/0')
+    expect(birthDateInitialized.mask('10/09')).toBe('10/09')
+    expect(birthDateInitialized.mask('10/091994')).toBe('10/09/1994')
   })
 
   it('should validate correctly', () => {
     const rules = defaultRules
-    const birthDate = filterDateType(rules.personalFields)[0]
+    const birthDateInitialized = getBirthDate(rules)
 
-    prepareDateRules(rules, intl)
-
-    expect(birthDate.validate('100')).toBeFalsy()
-    expect(birthDate.validate('10/09/1994')).toBeTruthy()
-    expect(birthDate.validate('29/02/1000')).toBeFalsy()
+    expect(birthDateInitialized.validate('100')).toBeFalsy()
+    expect(birthDateInitialized.validate('10/09/1994')).toBeTruthy()
+    expect(birthDateInitialized.validate('29/02/1000')).toBeFalsy()
   })
 
   it('should display correctly', () => {
     const rules = defaultRules
-    const birthDate = filterDateType(rules.personalFields)[0]
+    const birthDateInitialized = getBirthDate(rules)
 
-    prepareDateRules(rules, intl)
-
-    expect(birthDate.display('10/09/1994')).toBe('10/09/1994')
-    expect(birthDate.display('2018-11-25T00:00:00')).toBe('25/11/2018')
+    expect(birthDateInitialized.display('10/09/1994')).toBe('10/09/1994')
+    expect(birthDateInitialized.display('2018-11-25T00:00:00')).toBe(
+      '25/11/2018',
+    )
   })
 
   it('should submit correctly', () => {
     const rules = defaultRules
-    const birthDate = filterDateType(rules.personalFields)[0]
+    const birthDateInitialized = getBirthDate(rules)
 
-    prepareDateRules(rules, intl)
-
-    expect(birthDate.submit('25/11/2018')).toMatch(
+    expect(birthDateInitialized.submit('25/11/2018')).toMatch(
       new RegExp('2018-11-25T([0-9])([0-9]):00:00Z'),
     )
   })
@@ -81,21 +80,17 @@ describe('ProfileRules aux functions', () => {
   describe('date', () => {
     it('empty date should be submitted as null', () => {
       const rules = defaultRules
-      const birthDate = filterDateType(rules.personalFields)[0]
+      const birthDateInitialized = getBirthDate(rules)
 
-      prepareDateRules(rules, intl)
-
-      expect(birthDate.submit()).toBe(null)
+      expect(birthDateInitialized.submit()).toBe(null)
     })
 
     it('invalid date should be submitted as null', () => {
       const rules = defaultRules
-      const birthDate = filterDateType(rules.personalFields)[0]
+      const birthDateInitialized = getBirthDate(rules)
 
-      prepareDateRules(rules, intl)
-
-      expect(birthDate.submit('30/28/19501')).toBe(null)
-      expect(birthDate.submit('not-a-date')).toBe(null)
+      expect(birthDateInitialized.submit('30/28/19501')).toBe(null)
+      expect(birthDateInitialized.submit('not-a-date')).toBe(null)
     })
   })
 })

--- a/react/package.json
+++ b/react/package.json
@@ -1,1 +1,0 @@
-../package.json

--- a/react/package.json
+++ b/react/package.json
@@ -31,7 +31,7 @@
     "profile"
   ],
   "intl-equalizer": {
-    "localeDirectory": "messages/"
+    "localeDirectory": "../messages/"
   },
   "husky": {
     "hooks": {

--- a/react/package.json
+++ b/react/package.json
@@ -13,7 +13,7 @@
     "addLocales": "cp -R -f messages/ lib/locales/",
     "clean": "nwb clean-module && nwb clean-demo",
     "start": "npm run symlinks && nwb serve-react-demo",
-    "symlinks": "rm -rf src && ln -sf react src && ln -sf ../package.json react/package.json",
+    "symlinks": "rm -rf src && ln -sf react src",
     "test": "cd .. && jest --env=jsdom",
     "test:coverage": "jest --env=jsdom --coverage",
     "test:watch": "jest --env=jsdom --watch",

--- a/react/package.json
+++ b/react/package.json
@@ -1,0 +1,100 @@
+{
+  "name": "@vtex/profile-form",
+  "version": "2.6.9",
+  "description": "React component for managing user profiles",
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "build": "npm run symlinks && nwb build-react-component --no-demo && npm run removeMocks && npm run addLocales",
+    "build:link": "npm link && watch 'npm run build' src",
+    "removeMocks": "rm -rf lib/**/__mocks__ && rm -rf lib/__mocks__",
+    "addLocales": "cp -R -f messages/ lib/locales/",
+    "clean": "nwb clean-module && nwb clean-demo",
+    "start": "npm run symlinks && nwb serve-react-demo",
+    "symlinks": "rm -rf src && ln -sf react src && ln -sf ../package.json react/package.json",
+    "test": "jest --env=jsdom",
+    "test:coverage": "jest --env=jsdom --coverage",
+    "test:watch": "jest --env=jsdom --watch",
+    "vtex:link": "npm run symlinks && vtex link",
+    "prepublishOnly": "npm run build",
+    "lint:messages": "intl-equalizer"
+  },
+  "repository": "https://github.com/vtex/profile-form",
+  "author": "Gustavo Silva (@akafts)",
+  "license": "AGPL-3.0-only",
+  "homepage": "https://github.com/vtex/profile-form",
+  "keywords": [
+    "react-component",
+    "vtex",
+    "profile"
+  ],
+  "intl-equalizer": {
+    "localeDirectory": "messages/"
+  },
+  "husky": {
+    "hooks": {
+      "pre-push": "yarn lint:messages && yarn test"
+    }
+  },
+  "jest": {
+    "setupTestFrameworkScriptFile": "<rootDir>/react/__tests__/setupTests.js",
+    "testURL": "http://localhost",
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "<rootDir>/es/",
+      "<rootDir>/lib/",
+      "<rootDir>/umd/",
+      "<rootDir>/src/",
+      "setupTests"
+    ],
+    "modulePathIgnorePatterns": [
+      "<rootDir>/es/",
+      "<rootDir>/lib/",
+      "<rootDir>/umd/",
+      "<rootDir>/src/"
+    ],
+    "transformIgnorePatterns": [
+      "[/\\\\]lib[/\\\\].+\\.(js|jsx)$",
+      "[/\\\\]umd[/\\\\].+\\.(js|jsx)$",
+      "[/\\\\]es[/\\\\].+\\.(js|jsx)$",
+      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
+    ],
+    "moduleNameMapper": {
+      "\\.(css|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)(\\?.*)?$": "identity-obj-proxy"
+    },
+    "transform": {
+      "^.+\\.js$": "<rootDir>/jest.transform.js"
+    }
+  },
+  "dependencies": {
+    "@vtex/phone": "^4.8.0",
+    "@vtex/styleguide": "^5.4.4",
+    "downshift": "^2.0.20",
+    "match-sorter": "^2.2.3",
+    "moment": "^2.22.2",
+    "msk": "^1.0.3",
+    "react": "^16.4.1",
+    "react-intl": "^2.4.0"
+  },
+  "devDependencies": {
+    "@vtex/intl-equalizer": "^2.3.0",
+    "babel-jest": "^23.6.0",
+    "babel-plugin-add-react-displayname": "0.0.5",
+    "babel-preset-react-app": "^3.1.2",
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "^1.1.1",
+    "enzyme-react-intl": "^2.0.0",
+    "husky": "^2.3.0",
+    "jest": "^22.4.4",
+    "jest-enzyme": "^6.0.2",
+    "nwb": "^0.21.5",
+    "react-dom": "^16.4.1",
+    "react-hot-loader": "^4.3.4",
+    "react-test-renderer": "^16.4.1"
+  },
+  "peerDependencies": {
+    "vtex-tachyons": "^2.5.0"
+  }
+}

--- a/react/package.json
+++ b/react/package.json
@@ -14,7 +14,7 @@
     "clean": "nwb clean-module && nwb clean-demo",
     "start": "npm run symlinks && nwb serve-react-demo",
     "symlinks": "rm -rf src && ln -sf react src && ln -sf ../package.json react/package.json",
-    "test": "jest --env=jsdom",
+    "test": "cd .. && jest --env=jsdom",
     "test:coverage": "jest --env=jsdom --coverage",
     "test:watch": "jest --env=jsdom --watch",
     "vtex:link": "npm run symlinks && vtex link",
@@ -39,7 +39,7 @@
     }
   },
   "jest": {
-    "setupTestFrameworkScriptFile": "<rootDir>/react/__tests__/setupTests.js",
+    "setupTestFrameworkScriptFile": "./__tests__/setupTests.js",
     "testURL": "http://localhost",
     "testPathIgnorePatterns": [
       "/node_modules/",
@@ -65,7 +65,7 @@
       "\\.(css|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)(\\?.*)?$": "identity-obj-proxy"
     },
     "transform": {
-      "^.+\\.js$": "<rootDir>/jest.transform.js"
+      "^.+\\.js$": "../jest.transform.js"
     }
   },
   "dependencies": {

--- a/react/rules/ARG.js
+++ b/react/rules/ARG.js
@@ -3,7 +3,7 @@ import argentina from '@vtex/phone/countries/ARG'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(argentina)
 
@@ -51,7 +51,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/ARG.js
+++ b/react/rules/ARG.js
@@ -50,6 +50,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/ARG.js
+++ b/react/rules/ARG.js
@@ -3,6 +3,7 @@ import argentina from '@vtex/phone/countries/ARG'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(argentina)
 

--- a/react/rules/BRA.js
+++ b/react/rules/BRA.js
@@ -1,9 +1,9 @@
 import msk from 'msk'
 import brazil from '@vtex/phone/countries/BRA'
-import { isFutureDate } from '../utils/dateRules'
 
 import { getPhoneFields } from '../modules/phone'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(brazil)
 

--- a/react/rules/BRA.js
+++ b/react/rules/BRA.js
@@ -1,5 +1,6 @@
 import msk from 'msk'
 import brazil from '@vtex/phone/countries/BRA'
+import { isFutureDate } from '../utils/dateRules'
 
 import { getPhoneFields } from '../modules/phone'
 import initialize from './initializeCountryPhone'
@@ -77,6 +78,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/BRA.js
+++ b/react/rules/BRA.js
@@ -3,7 +3,7 @@ import brazil from '@vtex/phone/countries/BRA'
 
 import { getPhoneFields } from '../modules/phone'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(brazil)
 
@@ -78,7 +78,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/CAN.js
+++ b/react/rules/CAN.js
@@ -2,6 +2,7 @@ import canada from '@vtex/phone/countries/CAN'
 
 import { getPhoneFields } from '../modules/phone'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(canada)
 

--- a/react/rules/CAN.js
+++ b/react/rules/CAN.js
@@ -2,7 +2,7 @@ import canada from '@vtex/phone/countries/CAN'
 
 import { getPhoneFields } from '../modules/phone'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(canada)
 
@@ -43,7 +43,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/CAN.js
+++ b/react/rules/CAN.js
@@ -42,6 +42,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/CHL.js
+++ b/react/rules/CHL.js
@@ -3,6 +3,7 @@ import chile from '@vtex/phone/countries/CHL'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(chile)
 

--- a/react/rules/CHL.js
+++ b/react/rules/CHL.js
@@ -3,7 +3,7 @@ import chile from '@vtex/phone/countries/CHL'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(chile)
 
@@ -108,7 +108,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/CHL.js
+++ b/react/rules/CHL.js
@@ -107,6 +107,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/COL.js
+++ b/react/rules/COL.js
@@ -3,6 +3,7 @@ import colombia from '@vtex/phone/countries/COL'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(colombia)
 

--- a/react/rules/COL.js
+++ b/react/rules/COL.js
@@ -3,7 +3,7 @@ import colombia from '@vtex/phone/countries/COL'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(colombia)
 
@@ -51,7 +51,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/COL.js
+++ b/react/rules/COL.js
@@ -50,6 +50,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/CRI.js
+++ b/react/rules/CRI.js
@@ -3,7 +3,7 @@ import costarica from '@vtex/phone/countries/CRI'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(costarica)
 
@@ -51,7 +51,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/CRI.js
+++ b/react/rules/CRI.js
@@ -50,6 +50,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/CRI.js
+++ b/react/rules/CRI.js
@@ -3,6 +3,7 @@ import costarica from '@vtex/phone/countries/CRI'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(costarica)
 

--- a/react/rules/ECU.js
+++ b/react/rules/ECU.js
@@ -117,6 +117,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/ECU.js
+++ b/react/rules/ECU.js
@@ -3,7 +3,7 @@ import ecuador from '@vtex/phone/countries/ECU'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(ecuador)
 
@@ -118,7 +118,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/ECU.js
+++ b/react/rules/ECU.js
@@ -3,6 +3,7 @@ import ecuador from '@vtex/phone/countries/ECU'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(ecuador)
 

--- a/react/rules/ESP.js
+++ b/react/rules/ESP.js
@@ -3,7 +3,7 @@ import spain from '@vtex/phone/countries/ESP'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(spain)
 
@@ -51,7 +51,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/ESP.js
+++ b/react/rules/ESP.js
@@ -50,6 +50,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/ESP.js
+++ b/react/rules/ESP.js
@@ -3,6 +3,7 @@ import spain from '@vtex/phone/countries/ESP'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(spain)
 

--- a/react/rules/FRA.js
+++ b/react/rules/FRA.js
@@ -2,7 +2,7 @@ import france from '@vtex/phone/countries/FRA'
 
 import { getPhoneFields } from '../modules/phone'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(france)
 
@@ -43,7 +43,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/FRA.js
+++ b/react/rules/FRA.js
@@ -2,6 +2,7 @@ import france from '@vtex/phone/countries/FRA'
 
 import { getPhoneFields } from '../modules/phone'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(france)
 

--- a/react/rules/FRA.js
+++ b/react/rules/FRA.js
@@ -42,6 +42,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/GBR.js
+++ b/react/rules/GBR.js
@@ -2,7 +2,7 @@ import gbr from '@vtex/phone/countries/GBR' // Used for initialization purposes,
 
 import { getPhoneFields } from '../modules/phone'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(gbr)
 
@@ -43,7 +43,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/GBR.js
+++ b/react/rules/GBR.js
@@ -2,6 +2,7 @@ import gbr from '@vtex/phone/countries/GBR' // Used for initialization purposes,
 
 import { getPhoneFields } from '../modules/phone'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(gbr)
 

--- a/react/rules/GBR.js
+++ b/react/rules/GBR.js
@@ -42,6 +42,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/GTM.js
+++ b/react/rules/GTM.js
@@ -52,6 +52,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/GTM.js
+++ b/react/rules/GTM.js
@@ -3,6 +3,7 @@ import guatemala from '@vtex/phone/countries/GTM'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(guatemala)
 

--- a/react/rules/GTM.js
+++ b/react/rules/GTM.js
@@ -3,7 +3,7 @@ import guatemala from '@vtex/phone/countries/GTM'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(guatemala)
 
@@ -53,7 +53,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/KOR.js
+++ b/react/rules/KOR.js
@@ -2,6 +2,7 @@ import korea from '@vtex/phone/countries/KOR'
 
 import { getPhoneFields } from '../modules/phone'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(korea)
 

--- a/react/rules/KOR.js
+++ b/react/rules/KOR.js
@@ -2,7 +2,7 @@ import korea from '@vtex/phone/countries/KOR'
 
 import { getPhoneFields } from '../modules/phone'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(korea)
 
@@ -49,7 +49,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/KOR.js
+++ b/react/rules/KOR.js
@@ -48,6 +48,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/MEX.js
+++ b/react/rules/MEX.js
@@ -3,6 +3,7 @@ import mexico from '@vtex/phone/countries/MEX'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(mexico)
 

--- a/react/rules/MEX.js
+++ b/react/rules/MEX.js
@@ -3,7 +3,7 @@ import mexico from '@vtex/phone/countries/MEX'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(mexico)
 
@@ -44,7 +44,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/MEX.js
+++ b/react/rules/MEX.js
@@ -43,6 +43,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/PAN.js
+++ b/react/rules/PAN.js
@@ -3,7 +3,7 @@ import panama from '@vtex/phone/countries/PAN'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(panama)
 
@@ -51,7 +51,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/PAN.js
+++ b/react/rules/PAN.js
@@ -50,6 +50,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/PAN.js
+++ b/react/rules/PAN.js
@@ -3,6 +3,7 @@ import panama from '@vtex/phone/countries/PAN'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(panama)
 

--- a/react/rules/PER.js
+++ b/react/rules/PER.js
@@ -3,7 +3,7 @@ import peru from '@vtex/phone/countries/PER'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(peru)
 
@@ -51,7 +51,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/PER.js
+++ b/react/rules/PER.js
@@ -3,6 +3,7 @@ import peru from '@vtex/phone/countries/PER'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(peru)
 

--- a/react/rules/PER.js
+++ b/react/rules/PER.js
@@ -50,6 +50,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/PRT.js
+++ b/react/rules/PRT.js
@@ -1,5 +1,5 @@
 import regexValidation from '../modules/regexValidation'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 export default {
   country: 'PRT',
@@ -43,7 +43,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/PRT.js
+++ b/react/rules/PRT.js
@@ -1,4 +1,5 @@
 import regexValidation from '../modules/regexValidation'
+import { isFutureDate } from '../utils/dateRules'
 
 export default {
   country: 'PRT',

--- a/react/rules/PRT.js
+++ b/react/rules/PRT.js
@@ -42,6 +42,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/PRY.js
+++ b/react/rules/PRY.js
@@ -50,6 +50,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/PRY.js
+++ b/react/rules/PRY.js
@@ -3,6 +3,7 @@ import paraguay from '@vtex/phone/countries/PRY'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(paraguay)
 

--- a/react/rules/PRY.js
+++ b/react/rules/PRY.js
@@ -3,7 +3,7 @@ import paraguay from '@vtex/phone/countries/PRY'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(paraguay)
 
@@ -51,7 +51,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/ROU.js
+++ b/react/rules/ROU.js
@@ -1,4 +1,4 @@
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 export default {
   country: 'ROU',
@@ -36,7 +36,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/ROU.js
+++ b/react/rules/ROU.js
@@ -33,7 +33,8 @@ export default {
       name: 'birthDate',
       maxLength: 30,
       label: 'birthDate',
-      type: 'date'
+      type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/ROU.js
+++ b/react/rules/ROU.js
@@ -1,3 +1,5 @@
+import { isFutureDate } from '../utils/dateRules'
+
 export default {
   country: 'ROU',
   personalFields: [

--- a/react/rules/URY.js
+++ b/react/rules/URY.js
@@ -71,6 +71,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/URY.js
+++ b/react/rules/URY.js
@@ -3,6 +3,7 @@ import uruguay from '@vtex/phone/countries/URY' // Used for initialization purpo
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(uruguay)
 

--- a/react/rules/URY.js
+++ b/react/rules/URY.js
@@ -3,7 +3,7 @@ import uruguay from '@vtex/phone/countries/URY' // Used for initialization purpo
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(uruguay)
 
@@ -72,7 +72,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/USA.js
+++ b/react/rules/USA.js
@@ -2,6 +2,7 @@ import usa from '@vtex/phone/countries/USA' // Used for initialization purposes,
 
 import { getPhoneFields } from '../modules/phone'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(usa)
 

--- a/react/rules/USA.js
+++ b/react/rules/USA.js
@@ -42,6 +42,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/USA.js
+++ b/react/rules/USA.js
@@ -2,7 +2,7 @@ import usa from '@vtex/phone/countries/USA' // Used for initialization purposes,
 
 import { getPhoneFields } from '../modules/phone'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(usa)
 
@@ -43,7 +43,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/VEN.js
+++ b/react/rules/VEN.js
@@ -3,6 +3,7 @@ import venezuela from '@vtex/phone/countries/VEN'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
+import { isFutureDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(venezuela)
 

--- a/react/rules/VEN.js
+++ b/react/rules/VEN.js
@@ -50,6 +50,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/rules/VEN.js
+++ b/react/rules/VEN.js
@@ -3,7 +3,7 @@ import venezuela from '@vtex/phone/countries/VEN'
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 const phoneCountryCode = initialize(venezuela)
 
@@ -51,7 +51,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/default.js
+++ b/react/rules/default.js
@@ -1,4 +1,4 @@
-import { isFutureDate } from '../utils/dateRules'
+import { isPastDate } from '../utils/dateRules'
 
 export default {
   country: 'UNI',
@@ -42,7 +42,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isFutureDate,
+      validate: isPastDate,
     },
   ],
   businessFields: [

--- a/react/rules/default.js
+++ b/react/rules/default.js
@@ -1,3 +1,5 @@
+import { isFutureDate } from '../utils/dateRules'
+
 export default {
   country: 'UNI',
   personalFields: [

--- a/react/rules/default.js
+++ b/react/rules/default.js
@@ -39,7 +39,8 @@ export default {
       name: 'birthDate',
       maxLength: 30,
       label: 'birthDate',
-      type: 'date'
+      type: 'date',
+      validate: isFutureDate,
     },
   ],
   businessFields: [

--- a/react/utils/dateRules.js
+++ b/react/utils/dateRules.js
@@ -1,0 +1,61 @@
+import moment from 'moment'
+import msk from 'msk'
+
+function filterDateType(fields) {
+  return fields.filter(rule => rule.type === 'date')
+}
+
+// merge the arr2 into arr1 based on a rule name
+// considering the arr2 value over the arr1
+function mergeArrays(arr1, arr2) {
+  const aux = {}
+  arr2.forEach(rule => (aux[rule.name] = rule))
+
+  return arr1.map(rule => {
+    return aux[rule.name] ? aux[rule.name] : rule
+  })
+}
+
+export function prepareDateRules(rules, intl) {
+  return {
+    ...rules,
+    personalFields: mergeArrays(
+      rules.personalFields,
+      setDateRuleValidations(filterDateType(rules.personalFields), intl),
+    ),
+  }
+}
+
+function setDateRuleValidations(rules, intl) {
+  if (rules) {
+    return rules.map(rule => {
+      const ruleCopy = { ...rule }
+      ruleCopy.mask = value => msk.fit(value, '99/99/9999')
+      ruleCopy.validate = value => {
+        const mom = moment.utc(value, 'L', intl.locale.toLowerCase())
+
+        return mom.isValid() && rule.validate(mom.unix())
+      }
+      ruleCopy.display = value =>
+        moment
+          .utc(value, [moment.ISO_8601, 'L'], intl.locale.toLowerCase())
+          .format('L')
+      ruleCopy.submit = value => {
+        if (!value) return null
+
+        const date = moment.utc(value, 'L', intl.locale.toLowerCase(), true)
+        if (!date.isValid()) return null
+
+        return date.format()
+      }
+      return ruleCopy
+    })
+  }
+  return rules
+}
+
+export function isFutureDate(unixTimestamp) {
+  const nowMS = Date.now() / 1000
+
+  return unixTimestamp - nowMS < 0
+}

--- a/react/utils/dateRules.js
+++ b/react/utils/dateRules.js
@@ -1,7 +1,7 @@
 import moment from 'moment'
 import msk from 'msk'
 
-function filterDateType(fields) {
+export function filterDateType(fields) {
   return fields.filter(rule => rule.type === 'date')
 }
 

--- a/react/utils/dateRules.js
+++ b/react/utils/dateRules.js
@@ -54,7 +54,7 @@ function setDateRuleValidations(rules, intl) {
   return rules
 }
 
-export function isFutureDate(unixTimestamp) {
+export function isPastDate(unixTimestamp) {
   const nowMS = Date.now() / 1000
 
   return unixTimestamp - nowMS < 0


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add validation for `birthDate` to be always a date in the past.

#### What problem is this solving?

`birthDates` in the future were allowed.

#### How should this be manually tested?

Go to the following page and try to insert a birth date in the future. You shouldn't be able to save it.

https://arthur--recorrenciaqa.myvtex.com/account#/profile?success=true

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.