### PR TITLE
Change required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.3.1] - 2020-03-16
+
 ### Changed
 
 - CHL's `document` field to optional.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- CHL's `document` field to optional.
+- ESP's `homePhone` field to optional.
+
 ## [3.3.0] - 2019-11-21
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "profile-form",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "title": "VTEX Profile-form",
   "description": "React component for managing user profiles",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/profile-form",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "React component for managing user profiles",
   "main": "lib/index.js",
   "files": [

--- a/react/rules/CHL.js
+++ b/react/rules/CHL.js
@@ -89,7 +89,7 @@ export default {
       name: 'document',
       maxLength: 50,
       label: 'CHL_rut',
-      required: true,
+      required: false,
       validate: validateRUT,
     },
     {

--- a/react/rules/ESP.js
+++ b/react/rules/ESP.js
@@ -39,6 +39,7 @@ export default {
       name: 'homePhone',
       maxLength: 30,
       label: 'homePhone',
+      required: false,
       ...getPhoneFields(phoneCountryCode),
     },
     {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Related to [ch33493](https://app.clubhouse.io/vtex/story/33493/remover-telefone-como-campo-obrigat%C3%B3rio-para-o-pais-esp-no-myaccount-este-campo-ja-n%C3%A3o-%C3%A9-obrigat%C3%B3rio-no-checkout) and [ch33492](https://app.clubhouse.io/vtex/story/33492/remover-document-como-campo-obrigat%C3%B3rio-para-o-pais-chl-no-myaccount).
The field `document` should be optional at CHL, as well as `homePhone` for ESP.

#### What problem is this solving?
Those fields shouldn't be required 

#### How should this be manually tested?
CHL https://bibi--unimarc.myvtex.com/account#/profile/edit
ESP https://bibi--drimjuguetes.myvtex.com/_secure/account#/profile/edit

#### Screenshots or example usage
CHL example:
Before:
![image](https://user-images.githubusercontent.com/27328184/76558154-8bf3ff00-647b-11ea-8102-b28748ac6817.png)
After:
![image](https://user-images.githubusercontent.com/27328184/76558197-9f06cf00-647b-11ea-9403-821836a9537a.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.