### PR TITLE
fix: Birthdate not saving for ro-RO due to format validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.3.3] - 2020
+
+### Fixed
+
+- changed `birthdate` field's mask function to match the ro_RO format from moment (`DD.MM.YYYY`)
+
 ## [3.3.2] - 2020-05-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.3.3] - 2020-10-08
-
 ### Fixed
 
 - changed `birthdate` field's mask function to match the ro_RO format from moment (`DD.MM.YYYY`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.3.3] - 2020
+## [3.3.3] - 2020-10-08
 
 ### Fixed
 

--- a/react/rules/ROU.js
+++ b/react/rules/ROU.js
@@ -1,4 +1,5 @@
 import { isPastDate } from '../utils/dateRules'
+import msk from 'msk'
 
 export default {
   country: 'ROU',
@@ -37,6 +38,7 @@ export default {
       label: 'birthDate',
       type: 'date',
       validate: isPastDate,
+      mask: (value) => msk.fit(value, '99.99.9999'),
     },
   ],
   businessFields: [

--- a/react/utils/dateRules.js
+++ b/react/utils/dateRules.js
@@ -30,7 +30,7 @@ function setDateRuleValidations(rules, intl) {
   if (rules) {
     return rules.map(rule => {
       const ruleCopy = { ...rule }
-      ruleCopy.mask = value => msk.fit(value, '99/99/9999')
+      ruleCopy.mask = rule.mask ? rule.mask : (value => msk.fit(value, '99/99/9999'));
       ruleCopy.validate = value => {
         const mom = moment.utc(value, 'L', intl.locale.toLowerCase())
 

--- a/react/utils/dateRules.js
+++ b/react/utils/dateRules.js
@@ -30,7 +30,7 @@ function setDateRuleValidations(rules, intl) {
   if (rules) {
     return rules.map(rule => {
       const ruleCopy = { ...rule }
-      ruleCopy.mask = rule.mask ? rule.mask : (value => msk.fit(value, '99/99/9999'));
+      ruleCopy.mask = rule.mask ? rule.mask : (value => msk.fit(value, '99/99/9999'))
       ruleCopy.validate = value => {
         const mom = moment.utc(value, 'L', intl.locale.toLowerCase())
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixing the save of birth date on profile edit for culture-info ro_RO

#### What problem is this solving?
Could not save the birth date because of wrong format, was DD/MM/YYYY and expected DD.MM.YYYY

#### How should this be manually tested?
Change the culture_info to ro_RO and try to save the profile. 

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)