### PR TITLE
[3.x] Added prop blockDocument to block field in user profile page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added 
+- Added prop `blockDocument` to Enables or disables editing the document field in my account
 
 ## [3.4.0] - 2021-01-06
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ Inputs and buttons inside `ProfileContainer` can be customized to fit the style 
 - **Input**: (default: `StyleguideInput`) Component to be used as input for the form fields
 - **ToggleBusinessButton**: Component to be used as a button for toggling business fields
 - **SubmitButton**: Component to be used as a submit button
-- **shouldShowExtendedGenders**: (default: `false`) Whether the gender input should display a wide list of genders or just male/female
+- **shouldShowExtendedGenders**: (default: `false`) Whether the gender input should display a wide list of genders or just male/
+female
 - **children**: Custom components to be added right before the business toggle button
 - **intl**: `react-intl` automatically injected util
+- **blockDocument**: Enables or disables editing the document field in my account page.
 
 ```js
 ProfileContainer.propTypes = {
@@ -155,6 +157,52 @@ Here, `ProfileContainer` will be injected with the fetched rules:
 >
   <ProfileContainer profile={profile} onSubmit={this.handleSubmit} />
 </ProfileRules>
+```
+
+### ProfileField
+
+This component that renders my account fields. It received new two more properties to make it possible to block the document field: `userProfile` and` blockDocument`
+
+#### Props
+
+- **`userProfile`**: User profile so that we can check if the saved document already exists in database.
+- **`blockDocument`**: Enables or disables editing the document field in my account page. This property comes from the my-account module
+
+
+```js
+<ProfileField
+key={field.name}
+field={field}
+data={profile[field.name]}
+options={options[field.name]}
+onFieldUpdate={this.handleFieldUpdate}
+Input={Input}
+userProfile={profile}
+blockDocument={this.props.blockDocument}
+ />
+```
+
+
+### Exemple:
+
+```js
+render() {
+    const { field, data, options, Input, userProfile, blockDocument } = this.props
+    if(blockDocument && field.name === 'document' && userProfile['document'].value !== null){
+      field.disabled = true      
+    }
+    return (
+      <Input
+        field={field}
+        data={data}
+        options={options}
+        inputRef={this.inputRef}
+        onChange={this.handleChange}
+        onBlur={this.handleBlur}
+      />
+    )
+  }
+}
 ```
 
 ### ProfileSummary

--- a/react/ProfileContainer.js
+++ b/react/ProfileContainer.js
@@ -89,6 +89,8 @@ class ProfileContainer extends Component {
               options={options[field.name]}
               onFieldUpdate={this.handleFieldUpdate}
               Input={Input}
+              userProfile={profile}
+              blockDocument={this.props.blockDocument}
             />
           ))}
         </div>

--- a/react/ProfileField.js
+++ b/react/ProfileField.js
@@ -35,7 +35,11 @@ class ProfileField extends Component {
   }
 
   render() {
-    const { field, data, options, Input } = this.props
+    const { field, data, options, Input, userProfile, blockDocument } = this.props
+
+    if(blockDocument && field.name === 'document' && userProfile['document'].value !== null){
+      field.disabled = true      
+    }
     return (
       <Input
         field={field}


### PR DESCRIPTION
#### What is the purpose of this pull request?
This is not a problem resolution, just an improvement to allow blocking the field on my account page

#### What problem is this solving?
The customer needed to block the document field (cpf). Once added, the user should no longer edit. The customer wanted unique accounts per user.

#### How should this be manually tested?
1. Pass the blockDocument property in the declaration of the my-account application in the store

2. Link the vtex.my-account application to the tksio-549 branch in the my-account module. It is a dependency.

3. Link the three store / my-account / profile-form repositories and change the property value in the store. By default, the speaker is insufficient.
If you do not pass the property or pass the false value, the field allows changes.
If it is set to true and the field still has no saved value, the field will also allow editing, if the field is already saved, the field is blocked.

#### WS to test
https://profileform--tokstokio.myvtex.com/account/#/profile/edit

#### Screenshots or example usage

#### prop
![image](https://user-images.githubusercontent.com/78736383/107517863-0e55d900-6b8d-11eb-9d11-9ae9a0265ca8.png)

#### Before
![bofore](https://user-images.githubusercontent.com/78736383/107517888-19106e00-6b8d-11eb-8f8c-77a701b6d3b7.PNG)

#### After
![affter](https://user-images.githubusercontent.com/78736383/107517922-24fc3000-6b8d-11eb-9b42-754ca294a8d2.PNG)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.