### PR TITLE
Added prop blockDocument to Enables or disables editing the document …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Added prop `blockDocument` to Enables or disables editing the document field in my account
 ## [2.9.3] - 2021-01-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Inputs and buttons inside `ProfileContainer` can be customized to fit the style 
 - **shouldShowExtendedGenders**: (default: `false`) Whether the gender input should display a wide list of genders or just male/female
 - **children**: Custom components to be added right before the business toggle button
 - **intl**: `react-intl` automatically injected util
+- **blockDocument**: Enables or disables editing the document field in my account page.
 
 ```js
 ProfileContainer.propTypes = {
@@ -157,6 +158,51 @@ Here, `ProfileContainer` will be injected with the fetched rules:
 </ProfileRules>
 ```
 
+### ProfileField
+
+This component that renders my account fields. It received new two more properties to make it possible to block the document field: `userProfile` and` blockDocument`
+
+#### Props
+
+- **`userProfile`**: User profile so that we can check if the saved document already exists in database.
+- **`blockDocument`**: Enables or disables editing the document field in my account page. This property comes from the my-account module
+
+
+```js
+<ProfileField
+key={field.name}
+field={field}
+data={profile[field.name]}
+options={options[field.name]}
+onFieldUpdate={this.handleFieldUpdate}
+Input={Input}
+userProfile={profile}
+blockDocument={this.props.blockDocument}
+ />
+```
+
+
+### Exemple:
+
+```js
+render() {
+    const { field, data, options, Input, userProfile, blockDocument } = this.props
+    if(blockDocument && field.name === 'document' && userProfile['document'].value !== null){
+      field.disabled = true      
+    }
+    return (
+      <Input
+        field={field}
+        data={data}
+        options={options}
+        inputRef={this.inputRef}
+        onChange={this.handleChange}
+        onBlur={this.handleBlur}
+      />
+    )
+  }
+}
+```
 ### ProfileSummary
 
 This component takes in a profile object and a set of rules and prepares the data for displaying. Its main advantages are handling the translation of the labels and informing which fields should be hidden, but it also does some parsing logic such as translating gender and masking phone.

--- a/react/ProfileContainer.js
+++ b/react/ProfileContainer.js
@@ -91,6 +91,8 @@ class ProfileContainer extends Component {
               options={options[field.name]}
               onFieldUpdate={this.handleFieldUpdate}
               Input={Input}
+              userProfile={profile}
+              blockDocument={this.props.blockDocument}
             />
           ))}
         </div>

--- a/react/ProfileField.js
+++ b/react/ProfileField.js
@@ -35,7 +35,11 @@ class ProfileField extends Component {
   }
 
   render() {
-    const { field, data, options, Input } = this.props
+      const { field, data, options, Input, userProfile, blockDocument } = this.props
+
+    if(blockDocument && field.name === 'document' && userProfile['document'].value !== null){
+      field.disabled = true      
+    }
     return (
       <Input
         field={field}


### PR DESCRIPTION
#### What is the purpose of this pull request?
This is not a problem resolution, just an improvement to allow blocking the field on my account page

#### What problem is this solving?
The customer needed to block the document field (cpf). Once added, the user should no longer edit. The customer wanted unique accounts per user.

#### How should this be manually tested?
1. Pass the blockDocument property in the declaration of the my-account application in the store

2. Link the vtex.my-account application to the tksio-549 branch in the my-account module. It is a dependency.

3. Link the three store / my-account / profile-form repositories and change the property value in the store. By default, the speaker is insufficient.
If you do not pass the property or pass the false value, the field allows changes.
If it is set to true and the field still has no saved value, the field will also allow editing, if the field is already saved, the field is blocked.

#### WS to test
https://profileform--tokstokio.myvtex.com/account/#/profile/edit

#### Screenshots or example usage

#### prop
![image](https://user-images.githubusercontent.com/65731201/111346050-9af82900-865c-11eb-8173-81e0e0ff04f7.png)


#### Before
![image](https://user-images.githubusercontent.com/65731201/111346098-a77c8180-865c-11eb-85b9-199deb242753.png)


#### After
![image](https://user-images.githubusercontent.com/65731201/111346150-b5320700-865c-11eb-96b4-1027727ec851.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.