### PR TITLE
Bugfix/tksio 549

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added 
+- Added verification if the user's document is empty
 - Added prop `blockDocument` to Enables or disables editing the document field in my account
 
 ## [3.4.0] - 2021-01-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added 
-- Added verification if the user's document is empty
+- Add verification if the user's document is empty not only null 
 - Added prop `blockDocument` to Enables or disables editing the document field in my account
 
 ## [3.4.0] - 2021-01-06

--- a/react/ProfileField.js
+++ b/react/ProfileField.js
@@ -43,6 +43,7 @@ class ProfileField extends Component {
 
     render() {
         const { field, data, options, Input, userProfile, blockDocument } = this.props
+
         if (blockDocument && field.name === 'document' && (userProfile['document'].value !== null && userProfile['document'].value !== "")) {
             field.disabled = true
         }

--- a/react/ProfileField.js
+++ b/react/ProfileField.js
@@ -5,65 +5,70 @@ import RuleFieldShape from './RuleFieldShape'
 import ProfileFieldShape from './ProfileFieldShape'
 
 class ProfileField extends Component {
-  componentDidUpdate() {
-    const { field, data, onFieldUpdate } = this.props
-    if (data.focus && this.el) {
-      this.el.focus()
-      onFieldUpdate({ [field.name]: { ...data, focus: false } })
+    componentDidUpdate() {
+        const { field, data, onFieldUpdate } = this.props
+        if (data.focus && this.el) {
+            this.el.focus()
+            onFieldUpdate({
+                [field.name]: {...data, focus: false }
+            })
+        }
     }
-  }
 
-  handleChange = e => {
-    const { field, data, onFieldUpdate } = this.props
-    const { value } = e.target
+    handleChange = e => {
+        const { field, data, onFieldUpdate } = this.props
+        const { value } = e.target
 
-    const error = data.touched ? applyValidation(field, value) : null
-    const maskedValue = applyMask(field, value)
+        const error = data.touched ? applyValidation(field, value) : null
+        const maskedValue = applyMask(field, value)
 
-    onFieldUpdate({ [field.name]: { ...data, value: maskedValue, error } })
-  }
-
-  handleBlur = () => {
-    const { field, data, onFieldUpdate } = this.props
-    const error = applyValidation(field, data.value)
-
-    onFieldUpdate({ [field.name]: { ...data, touched: true, error } })
-  }
-
-  inputRef = el => {
-    this.el = el
-  }
-
-  render() {
-    const { field, data, options, Input, userProfile, blockDocument } = this.props
-
-    if(blockDocument && field.name === 'document' && userProfile['document'].value !== null){
-      field.disabled = true      
+        onFieldUpdate({
+            [field.name]: {...data, value: maskedValue, error }
+        })
     }
-    return (
-      <Input
-        field={field}
-        data={data}
-        options={options}
-        inputRef={this.inputRef}
-        onChange={this.handleChange}
-        onBlur={this.handleBlur}
-      />
-    )
-  }
+
+    handleBlur = () => {
+        const { field, data, onFieldUpdate } = this.props
+        const error = applyValidation(field, data.value)
+
+        onFieldUpdate({
+            [field.name]: {...data, touched: true, error }
+        })
+    }
+
+    inputRef = el => {
+        this.el = el
+    }
+
+
+    render() {
+        const { field, data, options, Input, userProfile, blockDocument } = this.props
+        if (blockDocument && field.name === 'document' && (userProfile['document'].value !== null && userProfile['document'].value !== "")) {
+            field.disabled = true
+        }
+        return ( <
+            Input field = { field }
+            data = { data }
+            options = { options }
+            inputRef = { this.inputRef }
+            onChange = { this.handleChange }
+            onBlur = { this.handleBlur }
+            />
+        )
+    }
 }
 
 ProfileField.propTypes = {
-  /** Rules for the field this component represents */
-  field: RuleFieldShape.isRequired,
-  /** Data to be displayed by this component */
-  data: ProfileFieldShape.isRequired,
-  /** Additional options to modify this input */
-  options: PropTypes.object,
-  /** Function to be called when data changes */
-  onFieldUpdate: PropTypes.func.isRequired,
-  /** Component to be used as input for the field */
-  Input: PropTypes.func.isRequired,
+    /** Rules for the field this component represents */
+    field: RuleFieldShape.isRequired,
+    /** Data to be displayed by this component */
+    data: ProfileFieldShape.isRequired,
+    /** Additional options to modify this input */
+    options: PropTypes.object,
+    /** Function to be called when data changes */
+    onFieldUpdate: PropTypes.func.isRequired,
+    /** Component to be used as input for the field */
+    Input: PropTypes.func.isRequired,
 }
 
 export default ProfileField


### PR DESCRIPTION
#### What is the purpose of this pull request?
Solve the problem of the document field (CPF) blocking even with the empty document.

#### What problem is this solving?
This pull request is for fixing a bug: When deleting the user's document, (CPF) it no longer returns null, but an empty string, with currently validating only null, so the system is blocking the document field even with the empty field. As a result, the user is unable to register the document for the first time.

#### How should this be manually tested?
1. Pass the blockDocument property in the declaration of the my-account application in the store

2. Link the vtex.my-account application to the tksio-549 branch in the my-account module. It is a dependency.

3. Link the three store / my-account / profile-form repositories and change the property value in the store. By default, the speaker is insufficient.
If you do not pass the property or pass the false value, the field allows changes.
If it is set to true and the field still has no saved value, the field will also allow editing, if the field is already saved, the field is blocked.

#### WS to test
https://profileform--tokstokio.myvtex.com/account/#/profile/edit

#### Screenshots or example usage

#### prop
![image](https://user-images.githubusercontent.com/65731201/111646432-69a86600-87e0-11eb-8657-07a4a570398d.png)


#### Before
![image](https://user-images.githubusercontent.com/65731201/111646497-775deb80-87e0-11eb-970d-d923e4910119.png)

#### After
![image](https://user-images.githubusercontent.com/65731201/111646594-8ba1e880-87e0-11eb-88d7-182a72057ff2.png)


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.