### PR TITLE
Solve Document Field Problems with the blockDocument property (CPF) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add verification if the user's document is filled with the blockDocument property
 
 ## [2.15.0] - 2021-11-04
 

--- a/react/ProfileField.js
+++ b/react/ProfileField.js
@@ -20,7 +20,7 @@ class ProfileField extends Component {
     const error = data.touched ? applyValidation(field, value) : null
     const maskedValue = applyMask(field, value)
 
-    onFieldUpdate({ [field.name]: { ...data, value: maskedValue, error } })
+    onFieldUpdate({ [field.name]: { ...data, value: maskedValue, error, active: true  }})
   }
 
   handleBlur = () => {
@@ -37,8 +37,8 @@ class ProfileField extends Component {
   render() {
       const { field, data, options, Input, userProfile, blockDocument } = this.props
 
-    if(blockDocument && field.name === 'document' && userProfile['document'].value !== null){
-      field.disabled = true      
+    if(blockDocument && field.name === 'document' &&  userProfile.document.value.length >= 14 && !userProfile.document.hasOwnProperty('active')) {
+      field.disabled = true
     }
     return (
       <Input


### PR DESCRIPTION
#### What is the purpose of this pull request?
Solve the problems of the document field (CPF). This fix also fixes the problem that this PR is fixing [Solve the problem of the document field (CPF) blocking even with the empty document.](https://github.com/vtex/profile-form/pull/104)

#### What problem is this solving?
This pull request is for fixing bugs, currently, this block document property has two issues that have been resolved in this PR:

1. The field is blocked as soon as the user enters 1 digit
2. The field remains blocked if someone removes the document from that account

#### How should this be manually tested?
1. Pass the blockDocument property in the declaration of the my-account application in the store

2. Link the vtex.my-account application to the tksio-549 branch in the my-account module. It is a dependency.

3. Link the three store / my-account / profile-form repositories and change the property value in the store. By default, the speaker is insufficient.
If you do not pass the property or pass the false value, the field allows changes.
If it is set to true and the field still has no saved value, the field will also allow editing, if the field is already saved, the field is blocked.

### WS to test
[https://dcnv208--tokstokio.myvtex.com](https://dcnv208--tokstokio.myvtex.com/)


#### Screenshots or example usage

### 1st bugfix

### Before
![image](https://user-images.githubusercontent.com/60629701/143254875-448d52f1-d310-4a52-9150-39c7ec9a574c.png)
![image](https://user-images.githubusercontent.com/60629701/143254880-4f1fa5cb-0cdb-45b4-8e4a-82ebe090442a.png)

https://user-images.githubusercontent.com/60629701/143255790-de3a70f5-45ba-4864-9f8b-acb023e2c782.mp4

### After

![image](https://user-images.githubusercontent.com/60629701/143255116-e52eb4c4-ebde-47da-b822-846a3fdfc027.png)
![image](https://user-images.githubusercontent.com/60629701/143255238-24df5f91-79a6-4d8d-95a3-cc29186a52eb.png)
field only block after submit
![image](https://user-images.githubusercontent.com/60629701/143255293-5896b98b-1c8a-4e3d-a8ac-43a26055b5a4.png)

https://user-images.githubusercontent.com/60629701/143255824-b683246b-1c04-4dc1-8179-eec0d608b0c0.mp4


### 2nd bugfix

### Before

![image](https://user-images.githubusercontent.com/60629701/143256792-421487c4-182f-4b7f-85ad-6749b368fcdc.png)

### After

![image](https://user-images.githubusercontent.com/60629701/143256830-c04d08b8-52a6-4458-a2b7-633901fc8ca8.png)


#### Types of changes


- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.