### PR TITLE
Fix birthdate mask to save this field properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove mask using `.` as separator in `birthdate` field for `IND` rules.
+
 ## [3.12.0] - 2022-02-18
 
 ### Added
@@ -65,10 +69,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [3.7.0] - 2021-04-22
 
 ### Added
+
 - I18n Denmark
-- I18n Deutschland 
+- I18n Deutschland
 - I18n Finnland
 - I18n Sweden
+
 ## [3.6.0] - 2021-04-19
 
 ### Added
@@ -84,7 +90,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - I18n Ro.
 
 ## [3.5.0] - 2021-03-17
-### Added 
+
+### Added
+
 - Added prop `blockDocument` to Enables or disables editing the document field in my account
 
 ## [3.4.0] - 2021-01-06

--- a/react/rules/IND.js
+++ b/react/rules/IND.js
@@ -43,8 +43,7 @@ export default {
       maxLength: 30,
       label: 'birthDate',
       type: 'date',
-      validate: isPastDate,
-      mask: (value) => msk.fit(value, '99.99.9999'),
+      validate: isPastDate
     },
   ],
   businessFields: [


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove mask for the `birthDate` field to allow this field to be saved.

#### What problem is this solving?

The mask it currently has doesn't work because it will parse to an invalid date here: https://github.com/vtex/profile-form/blob/master/react/utils/dateRules.js#L46

#### How should this be manually tested?

Try to update the `Birth date` field here:
https://arthur--whirlpoolindia.myvtex.com/account#/profile

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.