### PR TITLE
better RO translation

### DIFF
--- a/messages/ro.json
+++ b/messages/ro.json
@@ -10,7 +10,7 @@
   "profile-form.field.custom-gender": "Gen personalizat",
   "profile-form.field.document": "Document",
   "profile-form.field.birthDate": "Data nașterii",
-  "profile-form.field.homePhone": "Telefon fix",
+  "profile-form.field.homePhone": "Telefon",
   "profile-form.field.businessPhone": "Telefon corporativ",
   "profile-form.field.corporateDocument": "Documentul companiei",
   "profile-form.field.corporateName": "Nume companie",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change to RO translation.

#### What problem is this solving?
In Romania nobody has a fixed telephone anymore, so it should only be "Telefon".