### PR TITLE
[Fix][OMS-3116] State registration in ROU rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Added `stateRegistration` to `ROU` rule.
+
 ## [3.13.4] - 2022-08-02
 
 ### Fixed

--- a/react/rules/ROU.js
+++ b/react/rules/ROU.js
@@ -58,6 +58,11 @@ export default {
       label: 'corporateDocument',
     },
     {
+      name: 'stateRegistration',
+      maxLength: 50,
+      label: 'stateRegistration',
+    },
+    {
       name: 'businessPhone',
       maxLength: 30,
       label: 'businessPhone',


### PR DESCRIPTION
> Slack thread: https://vtex.slack.com/archives/G016AGYHTV2/p1660327270385829
> Jira issue: https://vtex-dev.atlassian.net/browse/OMS-3116

#### What is the purpose of this pull request?

Add stateRegistration in `ROU` rules.

<!--- Describe your changes in detail. -->

#### What problem is this solving?

Since this field wasn't present in `ROU` rules, the `ProfileSummary` component wasn't passing down this info.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Before](https://elefantqa.myvtex.com/admin/orders/1246691382866-01) vs [After](https://vini--elefantqa.myvtex.com/admin/orders/1246691382866-01)

#### Screenshots or example usage

<img width="688" alt="image" src="https://user-images.githubusercontent.com/28812834/184431872-1ef19f67-a247-421e-9d7b-b0fd4482700f.png">
<img width="672" alt="image" src="https://user-images.githubusercontent.com/28812834/184431906-129092c2-3e07-4efe-bcce-9878826b986a.png">


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.