### PR TITLE
fix: adjust birthday rule

### DIFF
--- a/react/rules/BRA.js
+++ b/react/rules/BRA.js
@@ -77,7 +77,7 @@ export default {
       name: 'birthDate',
       maxLength: 30,
       label: 'birthDate',
-      type: 'date',
+      mask: (value) => msk.fit(value, '99/99/9999'),
       validate: isPastDate,
     },
   ],

--- a/react/utils/dateRules.js
+++ b/react/utils/dateRules.js
@@ -2,7 +2,7 @@ import moment from 'moment'
 import msk from 'msk'
 
 export function filterDateType(fields) {
-  return fields.filter(rule => rule.type === 'date')
+  return fields.filter(rule => rule.type === 'date' || rule.label === "birthDate")
 }
 
 // merge the arr2 into arr1 based on a rule name
@@ -33,8 +33,9 @@ function setDateRuleValidations(rules, intl) {
       ruleCopy.mask = rule.mask ? rule.mask : (value => msk.fit(value, '99/99/9999'))
       ruleCopy.validate = value => {
         const mom = moment.utc(value, 'L', intl.locale.toLowerCase())
+        const currValidate = rule.validate === undefined ? true : rule.validate(value);
 
-        return mom.isValid() && rule.validate(mom.unix())
+        return mom.isValid() && currValidate
       }
       ruleCopy.display = value =>
         moment
@@ -54,8 +55,8 @@ function setDateRuleValidations(rules, intl) {
   return rules
 }
 
-export function isPastDate(unixTimestamp) {
-  const nowMS = Date.now() / 1000
-
-  return unixTimestamp - nowMS < 0
+export function isPastDate(dateString) {
+  const date = moment(dateString, 'DD/MM/YYYY', true);
+  const now = moment();
+  return date.isValid() && date.isBefore(now);
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
When type is Date, it receives a UnixTime which is not usefull, as it considers:
- 01/01 as 31/12/2023
- 01/01/01 as 31/12/2001

The inputs that we want to be validated are in the format 99/99/9999

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.