### PR TITLE
WIP Hotfix / Hungarian value update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Hungarian validation to match hungarian mask when last dot is missing
+
 ## [3.16.4] - 2024-05-03
 
 ### Fixed

--- a/react/modules/validateProfile.js
+++ b/react/modules/validateProfile.js
@@ -16,7 +16,7 @@ export function applyValidation(field, value) {
 
 export function applyFullValidation(rules, profile, isCorporate) {
 
-  if(rules.country === 'HUN' && profile?.birthDate?.value){
+  if(rules.country === 'HUN' && profile.birthDate.value){
     hungarianDateValidation(profile)
   }
 

--- a/react/modules/validateProfile.js
+++ b/react/modules/validateProfile.js
@@ -16,7 +16,7 @@ export function applyValidation(field, value) {
 
 export function applyFullValidation(rules, profile, isCorporate) {
 
-  if(rules.country === 'HUN' && profile.birthDate.value){
+  if (rules.country === 'HUN' && profile.birthDate.value) {
     hungarianDateValidation(profile)
   }
 

--- a/react/modules/validateProfile.js
+++ b/react/modules/validateProfile.js
@@ -1,3 +1,5 @@
+import { MINIMUM_EXPECTED_DATE_LENGTH } from '../utils/dateRules.js'
+
 export function applyMask(field, value) {
   return field.mask ? field.mask(value) : value
 }
@@ -13,6 +15,11 @@ export function applyValidation(field, value) {
 }
 
 export function applyFullValidation(rules, profile, isCorporate) {
+
+  if(rules.country === 'HUN' && profile?.birthDate?.value){
+    hungarianDateValidation(profile)
+  }
+
   const validatedProfile = Object.keys(profile)
     .map(field => {
       const rule =
@@ -51,3 +58,13 @@ function containsEmoji(input) {
 
   return EMOJIS_REGEX.test(input)
 }
+
+function hungarianDateValidation(profile) {
+  let profileDate = profile.birthDate.value
+  if (!profileDate.endsWith(".") && profileDate.length === MINIMUM_EXPECTED_DATE_LENGTH) {
+    profileDate += "."
+
+    profile.birthDate.value = profileDate
+  }
+}
+

--- a/react/utils/dateRules.js
+++ b/react/utils/dateRules.js
@@ -26,7 +26,7 @@ export function prepareDateRules(rules, intl) {
   }
 }
 
-const MINIMUM_EXPECTED_DATE_LENGTH = 10; // 99/99/9999 or 99.99.99.
+export const MINIMUM_EXPECTED_DATE_LENGTH = 10; // 99/99/9999 or 99.99.99.
 
 function setDateRuleValidations(rules, intl) {
   if (rules) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

We added a simple validation to the Hungarian birthDate field, ensuring that the date follows the structure yyyy.mm.dd. with a final dot. This validation enhances data integrity and adherence to the Hungarian date format standards.

The hungarian date mask have a specific structure that requires a dot at the end of the date, but the client wants the input to work with no dot as well for a better user experience.

#### What problem is this solving?
- Hungarian Birth Date input value

#### How should this be manually tested?
You can access the link below and try to add a new birth date to your profile
https://birthdate2--probeautyhu.myvtex.com/

#### Screenshots or example usage

https://github.com/vtex/profile-form/assets/53904010/b3b7bc0d-865f-48b8-9af2-a9b2a724f3fe

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.