### PR TITLE
Add: state for className

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- "...-disabled", "...-empty", "...-focused" and "...-invalid" classNames for the StyleguideInput component.
+- "...-required", "...-disabled", "...-empty", "...-focused" and "...-invalid" classNames for the StyleguideInput component.
 
 ## [3.17.0] - 2024-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- "...-disabled", "...-empty", "...-focused" and "...-invalid" classNames for the StyleguideInput component.
+
 ## [3.17.0] - 2024-06-14
 
 ### Added

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -8,15 +8,7 @@ import GenderInput from './GenderInput'
 import styles from '../../styles.css'
 
 const StyleguideInput = (props) => {
-  const {
-    field,
-    data,
-    options,
-    inputRef,
-    onChange,
-    onBlur,
-    intl,
-  } = props
+  const { field, data, options, inputRef, onChange, onBlur, intl } = props
 
   const [isFocused, setIsFocused] = useState(false)
 
@@ -24,17 +16,17 @@ const StyleguideInput = (props) => {
   const handleFocus = () => setIsFocused(true)
   const handleBlur = (e) => {
     onBlur(e)
-    setIsFocused(false)  
+    setIsFocused(false)
   }
 
   // Define class names based on the component state and props
   const containerClassNames = [
     styles.styleguideInput,
     field.hidden ? 'dn' : '',
-    field.required ? 'required' : '',
-    isFocused ? 'focused' : '',
-    data.error ? 'invalid' : '',
-    !data.value ? 'empty' : '',
+    field.required ? `${styles.styleguideInput}-required` : '',
+    isFocused ? `${styles.styleguideInput}-focused` : '',
+    data.error ? `${styles.styleguideInput}-invalid` : '',
+    !data.value ? `${styles.styleguideInput}-empty` : '',
     'pb7',
   ].join(' ')
 

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { intlShape, injectIntl } from 'react-intl'
 import Input from '@vtex/styleguide/lib/Input'
@@ -7,7 +7,7 @@ import ProfileFieldShape from '../../ProfileFieldShape'
 import GenderInput from './GenderInput'
 import styles from '../../styles.css'
 
-const StyleguideInput = props => {
+const StyleguideInput = (props) => {
   const {
     field,
     data,
@@ -17,6 +17,25 @@ const StyleguideInput = props => {
     onBlur,
     intl,
   } = props
+
+  const [isFocused, setIsFocused] = useState(false)
+
+  // Handle focus and blur events
+  const handleFocus = () => setIsFocused(true)
+  const handleBlur = (e) => {
+    onBlur(e)
+    setIsFocused(false)  
+  }
+
+  // Define class names based on the component state and props
+  const containerClassNames = [
+    styles.styleguideInput,
+    field.hidden ? 'dn' : '',
+    isFocused ? 'focused' : '',
+    data.error ? 'invalid' : '',
+    !data.value ? 'empty' : '',
+    'pb7',
+  ].join(' ')
 
   if (field.name === 'gender') {
     return (
@@ -28,11 +47,7 @@ const StyleguideInput = props => {
   }
 
   return (
-    <div
-      className={`${styles.styleguideInput} ${
-        field.hidden ? 'dn' : ''
-      } pb7`}
-    >
+    <div className={containerClassNames}>
       <Input
         name={field.name}
         label={intl.formatMessage({
@@ -51,7 +66,8 @@ const StyleguideInput = props => {
             : null
         }
         onChange={onChange}
-        onBlur={onBlur}
+        onBlur={handleBlur}
+        onFocus={handleFocus}
         ref={inputRef}
         maxLength={field.maxLength}
         disabled={field.disabled}
@@ -75,6 +91,11 @@ StyleguideInput.propTypes = {
   onBlur: PropTypes.func.isRequired,
   /** React-intl utility */
   intl: intlShape.isRequired,
+}
+
+StyleguideInput.defaultProps = {
+  options: {},
+  inputRef: () => {},
 }
 
 export default injectIntl(StyleguideInput)

--- a/react/inputs/StyleguideInput/index.js
+++ b/react/inputs/StyleguideInput/index.js
@@ -31,6 +31,7 @@ const StyleguideInput = (props) => {
   const containerClassNames = [
     styles.styleguideInput,
     field.hidden ? 'dn' : '',
+    field.required ? 'required' : '',
     isFocused ? 'focused' : '',
     data.error ? 'invalid' : '',
     !data.value ? 'empty' : '',


### PR DESCRIPTION
What is the purpose of this pull request?

Add additional classNames to the styleguide inputs. It will bring a possibility to customize the label color or position.

What problem is this solving?
In the design concept of our client the field label should have a red color when the field fails validation and since the label tag is on the upper level then input tag that has validation text, it's impossible to style it via CSS.

How should this be manually tested?
Just to check that these additional classNames are presented in the address form field HTML



#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.