### PR TITLE
Added Ireland ('IRL') country rules. Removed Spain personal ID validation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Ireland ('IRL') country rules.
+
+### Removed
+
+- Spain personal ID validation as a workaround to make sure store location changing works as expected for Dunnes.
+
+
 ## [2.21.0] - 2024-09-18
 
 ### Added

--- a/react/rules/IRL.js
+++ b/react/rules/IRL.js
@@ -1,14 +1,14 @@
-import spain from '@vtex/phone/countries/ESP'
+import ireland from '@vtex/phone/countries/IRL'
 
 import { getPhoneFields } from '../modules/phone'
 import regexValidation from '../modules/regexValidation'
 import initialize from './initializeCountryPhone'
 import { isPastDate } from '../utils/dateRules'
 
-const phoneCountryCode = initialize(spain)
+const phoneCountryCode = initialize(ireland)
 
 export default {
-  country: 'ESP',
+  country: 'IRL',
   personalFields: [
     {
       name: 'firstName',
@@ -31,7 +31,7 @@ export default {
     {
       name: 'document',
       maxLength: 50,
-      label: 'ESP_dni',
+      label: 'document',
       required: false,
     },
     {
@@ -68,8 +68,7 @@ export default {
     {
       name: 'corporateDocument',
       maxLength: 30,
-      label: 'ESP_cif',
-      validate: regexValidation(/^[A-z]{1}\d{8}$/),
+      label: 'corporateDocument',
     },
     {
       name: 'businessPhone',


### PR DESCRIPTION
#### What is the purpose of this pull request?
Added Ireland ('IRL') country rules. Removed Spain personal ID validation as a workaround to make sure store location changing works as expected for Dunnes.

#### What problem is this solving?
Users were unable to save profile info after changing store location. Check [LOC-21126](https://vtex-dev.atlassian.net/browse/LOC-21126) for details.

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

[LOC-21126]: https://vtex-dev.atlassian.net/browse/LOC-21126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ