### PR TITLE
[OMS-8223] fix: Austria (AUT) date mask format for birthDate field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.19.3] - 2025-10-30
+
 ### Fixed
 
 - Austria (AUT) date mask format for birthDate field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Austria (AUT) date mask format for birthDate field
+
 ## [3.19.2] - 2025-05-13
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "profile-form",
-  "version": "3.19.2",
+  "version": "3.19.3",
   "title": "VTEX Profile-form",
   "description": "React component for managing user profiles",
   "builders": {

--- a/react/rules/AUT.js
+++ b/react/rules/AUT.js
@@ -1,3 +1,4 @@
+import msk from 'msk'
 import { isPastDate } from '../utils/dateRules'
 
 export default {
@@ -41,8 +42,8 @@ export default {
       name: 'birthDate',
       maxLength: 30,
       label: 'birthDate',
-      type: 'date',
-      validate: isPastDate
+      validate: isPastDate,
+      mask: (value) => msk.fit(value, '99.99.9999'),
     },
   ],
   businessFields: [


### PR DESCRIPTION
#### What is the purpose of this pull request?

[Jira issue](https://vtex-dev.atlassian.net/browse/OMS-8223)

[Slack Thread](https://vtex.slack.com/archives/G016AGYHTV2/p1761590719063189)

This pull request ensures that user input for the `birthDate` field now follows the correct `99.99.9999` date format mask.

#### What problem is this solving?

This pull request addresses a bug with the Austria (AUT) date mask format for the `birthDate` field, detailed on this [Slack Thread](https://vtex.slack.com/archives/G016AGYHTV2/p1761590719063189).

#### How should this be manually tested?

Workspace: https://lalai--atmultibrandqa.myvtex.com/account#/profile?success=true

#### Screenshots or example usage

<img width="816" height="380" alt="image" src="https://github.com/user-attachments/assets/89a90f22-942e-423a-843a-8bb958891b4c" />


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.