### PR TITLE
SDD Skip config

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -9,6 +9,8 @@ metadata:
   annotations:
     vtex.com/janus-acronym: ""
     vtex.com/o11y-os-index: ""
+    vtex.com/sdd-check-skip: true
+    vtex.com/sdd-check-skip-reason: Legacy app in maintenance mode
     grafana/dashboard-selector: ""
     github.com/project-slug: vtex/profile-form
     vtex.com/platform-flow-id: Shopper#5


### PR DESCRIPTION
#### What is the purpose of this pull request?

This pull request makes a minor update to the `.vtex/catalog-info.yaml` metadata. The change adds annotations to skip the SDD check, with a reason indicating that this is a legacy app in maintenance mode.