### PR TITLE
feat: add native phone validation rules for Ireland (IRL)

### DIFF
--- a/react/rules/IRL.js
+++ b/react/rules/IRL.js
@@ -1,0 +1,67 @@
+import irl from '@vtex/phone/countries/IRL' // Used for initialization purposes, do not remove it!
+
+import { getPhoneFields } from '../modules/phone'
+import initialize from './initializeCountryPhone'
+import { isPastDate } from '../utils/dateRules'
+
+const phoneCountryCode = initialize(irl)
+
+export default {
+  country: 'IRL',
+  personalFields: [
+    {
+      name: 'firstName',
+      maxLength: 100,
+      label: 'firstName',
+      required: true,
+    },
+    {
+      name: 'lastName',
+      maxLength: 100,
+      label: 'lastName',
+      required: true,
+    },
+    {
+      name: 'email',
+      maxLength: 100,
+      label: 'email',
+      hidden: true,
+    },
+    {
+      name: 'homePhone',
+      maxLength: 30,
+      label: 'homePhone',
+      ...getPhoneFields(phoneCountryCode),
+    },
+    {
+      name: 'gender',
+      maxLength: 30,
+      label: 'gender',
+    },
+    {
+      name: 'birthDate',
+      maxLength: 30,
+      label: 'birthDate',
+      type: 'date',
+      validate: isPastDate,
+    },
+  ],
+  businessFields: [
+    {
+      name: 'corporateName',
+      maxLength: 100,
+      label: 'corporateName',
+    },
+    {
+      name: 'tradeName',
+      maxLength: 100,
+      label: 'tradeName',
+    },
+    {
+      name: 'businessPhone',
+      maxLength: 30,
+      label: 'businessPhone',
+      ...getPhoneFields(phoneCountryCode),
+    },
+  ],
+}

--- a/react/rules/initializeCountryPhone.js
+++ b/react/rules/initializeCountryPhone.js
@@ -2,6 +2,7 @@ import Phone from '@vtex/phone'
 
 export default function initialize(country) {
   const phoneCountryCode = country.countryCode
+
   Phone.countries[phoneCountryCode] = country
 
   return phoneCountryCode

--- a/react/utils/dateRules.js
+++ b/react/utils/dateRules.js
@@ -9,6 +9,7 @@ export function filterDateType(fields) {
 // considering the arr2 value over the arr1
 function mergeArrays(arr1, arr2) {
   const aux = {}
+
   arr2.forEach(rule => (aux[rule.name] = rule))
 
   return arr1.map(rule => {
@@ -21,7 +22,7 @@ export function prepareDateRules(rules, intl) {
     ...rules,
     personalFields: mergeArrays(
       rules.personalFields,
-      setDateRuleValidations(filterDateType(rules.personalFields), intl),
+      setDateRuleValidations(filterDateType(rules.personalFields), intl)
     ),
   }
 }
@@ -30,12 +31,16 @@ function setDateRuleValidations(rules, intl) {
   if (rules) {
     return rules.map(rule => {
       const ruleCopy = { ...rule }
-      ruleCopy.mask = rule.mask ? rule.mask : (value => msk.fit(value, '99/99/9999'))
+
+      ruleCopy.mask = rule.mask
+        ? rule.mask
+        : value => msk.fit(value, '99/99/9999')
       ruleCopy.validate = value => {
         const mom = moment.utc(value, 'L', intl.locale.toLowerCase())
 
         return mom.isValid() && rule.validate(mom.unix())
       }
+
       ruleCopy.display = value =>
         moment
           .utc(value, [moment.ISO_8601, 'L'], intl.locale.toLowerCase())
@@ -44,13 +49,16 @@ function setDateRuleValidations(rules, intl) {
         if (!value) return null
 
         const date = moment.utc(value, 'L', intl.locale.toLowerCase(), true)
+
         if (!date.isValid()) return null
 
         return date.format()
       }
+
       return ruleCopy
     })
   }
+
   return rules
 }
 


### PR DESCRIPTION
## Summary
- Adds `react/rules/IRL.js` following the same pattern as `GBR.js` and other country rules
- `@vtex/phone` already ships `countries/IRL` — no dependency changes needed
- Fixes Ireland stores falling back to `defaultRules` (no phone validation) instead of IRL-specific rules

## Context
ZD #1429680 — dunnesstores (Tier 1 / Strategic, Ireland). Stores with country IRL currently use `defaultRules` because `IRL.js` was missing. The phone library already supports IRL; only the rules file was absent.

## Test plan
- [ ] Configure a VTEX store with country IRL
- [ ] Open My Account → Profile
- [ ] Verify phone field validates with Irish format (+353)