### PR TITLE
feat: add native phone validation rules for Ireland (IRL)

### DIFF
--- a/react/rules/IRL.js
+++ b/react/rules/IRL.js
@@ -1,0 +1,67 @@
+import irl from '@vtex/phone/countries/IRL' // Used for initialization purposes, do not remove it!
+
+import { getPhoneFields } from '../modules/phone'
+import initialize from './initializeCountryPhone'
+import { isPastDate } from '../utils/dateRules'
+
+const phoneCountryCode = initialize(irl)
+
+export default {
+  country: 'IRL',
+  personalFields: [
+    {
+      name: 'firstName',
+      maxLength: 100,
+      label: 'firstName',
+      required: true,
+    },
+    {
+      name: 'lastName',
+      maxLength: 100,
+      label: 'lastName',
+      required: true,
+    },
+    {
+      name: 'email',
+      maxLength: 100,
+      label: 'email',
+      hidden: true,
+    },
+    {
+      name: 'homePhone',
+      maxLength: 30,
+      label: 'homePhone',
+      ...getPhoneFields(phoneCountryCode),
+    },
+    {
+      name: 'gender',
+      maxLength: 30,
+      label: 'gender',
+    },
+    {
+      name: 'birthDate',
+      maxLength: 30,
+      label: 'birthDate',
+      type: 'date',
+      validate: isPastDate,
+    },
+  ],
+  businessFields: [
+    {
+      name: 'corporateName',
+      maxLength: 100,
+      label: 'corporateName',
+    },
+    {
+      name: 'tradeName',
+      maxLength: 100,
+      label: 'tradeName',
+    },
+    {
+      name: 'businessPhone',
+      maxLength: 30,
+      label: 'businessPhone',
+      ...getPhoneFields(phoneCountryCode),
+    },
+  ],
+}

--- a/react/rules/IRL.js
+++ b/react/rules/IRL.js
@@ -1,10 +1,5 @@
-import irl from '@vtex/phone/countries/IRL' // Used for initialization purposes, do not remove it!
-
-import { getPhoneFields } from '../modules/phone'
-import initialize from './initializeCountryPhone'
+import msk from 'msk'
 import { isPastDate } from '../utils/dateRules'
-
-const phoneCountryCode = initialize(irl)
 
 export default {
   country: 'IRL',
@@ -31,7 +26,6 @@ export default {
       name: 'homePhone',
       maxLength: 30,
       label: 'homePhone',
-      ...getPhoneFields(phoneCountryCode),
     },
     {
       name: 'gender',
@@ -42,8 +36,8 @@ export default {
       name: 'birthDate',
       maxLength: 30,
       label: 'birthDate',
-      type: 'date',
       validate: isPastDate,
+      mask: (value) => msk.fit(value, '99/99/9999'),
     },
   ],
   businessFields: [
@@ -61,7 +55,6 @@ export default {
       name: 'businessPhone',
       maxLength: 30,
       label: 'businessPhone',
-      ...getPhoneFields(phoneCountryCode),
     },
   ],
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
This pull request adds a new configuration file for Ireland (`IRL`) to support country-specific form rules. The file defines the required personal and business fields, integrates phone number validation, and includes a custom date validation for birth dates.

**New country configuration:**

* Added `react/rules/IRL.js` to define personal and business fields for Ireland, including field names, validation rules, and integration with phone and date validation utilities.

#### What problem is this solving?

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.