### PR TITLE
fix: restore phone validation for IRL rules

### DIFF
--- a/react/rules/IRL.js
+++ b/react/rules/IRL.js
@@ -1,5 +1,11 @@
 import msk from 'msk'
+import irl from '@vtex/phone/countries/IRL' // Used for initialization purposes, do not remove it!
+
+import { getPhoneFields } from '../modules/phone'
+import initialize from './initializeCountryPhone'
 import { isPastDate } from '../utils/dateRules'
+
+const phoneCountryCode = initialize(irl)
 
 export default {
   country: 'IRL',
@@ -26,6 +32,7 @@ export default {
       name: 'homePhone',
       maxLength: 30,
       label: 'homePhone',
+      ...getPhoneFields(phoneCountryCode),
     },
     {
       name: 'gender',
@@ -55,6 +62,7 @@ export default {
       name: 'businessPhone',
       maxLength: 30,
       label: 'businessPhone',
+      ...getPhoneFields(phoneCountryCode),
     },
   ],
 }


### PR DESCRIPTION
## What is the purpose of this pull request?
Restores native phone number validation/masking for Ireland (`IRL`), which was inadvertently removed in #214.

## What problem is this solving?
PR #214 (merged into `3.x`) included a follow-up commit (`45b0d4f`, "package adjustments") that stripped out the `@vtex/phone` integration from `react/rules/IRL.js`:
- Removed the `import irl from '@vtex/phone/countries/IRL'` and `initializeCountryPhone` calls
- Removed `...getPhoneFields(phoneCountryCode)` from both `homePhone` and `businessPhone`

As a result, the deployed `IRL.js` has phone fields with no mask/validation at all — functionally equivalent to the `default` rules that existed before this feature. This is why the customer (ZD #1429680, dunnesstores) reports the fix is not working in production.

This PR restores the exact same pattern used by `GBR.js` on this branch, which still has the phone integration intact and working.

## How should this be manually tested?
1. Configure a test store's binding locale to `en-IE` (Trade Policies)
2. Open My Account → Profile
3. Verify the `homePhone` field now validates/masks in Irish phone format (+353)

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)