### PR TITLE
fix: accept G/P/C prefixes in Venezuela RIF validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Venezuela (`VEN`) RIF validation now accepts government (`G`), passport (`P`), and commune (`C`) prefixes in addition to `V`/`E`/`J` (LOC-27360).
+
 ## [2.21.0] - 2024-09-18
 
 ### Added

--- a/react/rules/VEN.js
+++ b/react/rules/VEN.js
@@ -69,7 +69,7 @@ export default {
       name: 'corporateDocument',
       maxLength: 30,
       label: 'VEN_rif',
-      validate: regexValidation(/^[VvJjEe]-?\d{6,8}-?\d$/),
+      validate: regexValidation(/^[VvJjEeGgPpCc]-?\d{6,8}-?\d$/),
     },
     {
       name: 'businessPhone',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Accept Venezuela government (and other SENIAT) RIF prefixes that checkout was rejecting. Tracked in [LOC-27360](https://vtex-dev.atlassian.net/browse/LOC-27360).

#### Summary

- Extend VEN `corporateDocument` (RIF) regex to allow `G`/`P`/`C` in addition to `V`/`E`/`J`
- Leave personal cédula validation unchanged (`V`/`E`/`J` only)

[LOC-27360]: https://vtex-dev.atlassian.net/browse/LOC-27360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ